### PR TITLE
Fix indirection when using `poll_throttled`.

### DIFF
--- a/src/briefkasten/indirection.hpp
+++ b/src/briefkasten/indirection.hpp
@@ -23,6 +23,7 @@
 #include <kassert/kassert.hpp>
 #include "./detail/concepts.hpp"  // IWYU pragma: keep
 #include "./detail/definitions.hpp"
+#include "./buffered_queue.hpp" // IWYU pragma: keep
 
 #include <kamping/measurements/timer.hpp>
 


### PR DESCRIPTION
This closes #11

Since `poll_throttled` was not defined on the `IndirectionAdapter`, it
was called directly on the underlying queue, bypassing the indirection
logic.

This commit also adds all other members of `BufferedQueue` that take a
message handler, ensuring that indirection is consistently applied.